### PR TITLE
Fix typo and revert manual edit

### DIFF
--- a/R/cor_get_n_strongest.r
+++ b/R/cor_get_n_strongest.r
@@ -3,7 +3,7 @@
 #' Takes a dataframe and calculates pairwise correlations between all numeric/logical variables. Returns a tibble with strongest n correlations. Might also return the p-value in the future. 
 #' @param df dataframe (e.g. tibble)
 #' @param n number of strongest correlations to return
-#' @param method type of correlationn, see \code{\link{stats::cor}}
+#' @param method type of correlation, see \code{\link{stats::cor}}
 #' @param use how to deal with missing values, see \code{\link{stats::cor}}
 #' @return tibble with columns var1, var2, r
 #' @seealso \code{\link{stats::cor}} which this function wraps


### PR DESCRIPTION
## Summary
- correct a typo in `cor_get_n_strongest` documentation
- revert manual page change since man files are auto-generated

## Testing
- `Rscript -e 'devtools::document()'` *(fails: command not found)*
- `R CMD check .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684093912e308325a2cd0fddad452475